### PR TITLE
fixed bug

### DIFF
--- a/lib/error-responses.js
+++ b/lib/error-responses.js
@@ -18,7 +18,11 @@ function invalidAction(name) {
 }
 
 function noEvaluationAction() {
-    return 'There is no evaluation intent in the actions.js file (in the skill), add it and try again'
+    return 'There is no evaluation intent in the actions.js file (in the skill), add it and try again';
+}
+
+function noNluDeclared() {
+    return `Could not evaluate request, no NLU engines declared in the manifest`;
 }
 
 // Return response errors
@@ -27,5 +31,6 @@ module.exports = {
     invalidNluType: invalidNluType,
     couldNotReadNluType: couldNotReadNluType,
     invalidAction: invalidAction,
-    noEvaluationAction: noEvaluationAction
+    noEvaluationAction: noEvaluationAction,
+    noNluDeclared: noNluDeclared
 };

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -43,6 +43,11 @@ Handler.prototype.initialize = function () {
  * @param callback - a callback function that gets the evaluation response
  */
 Handler.prototype.handleEvaluationRequest = function (request, callback) {
+    if(!this.engines || this.engines.length < 2) {
+        callback({responseCode: 501, requestResult: errors.noNluDeclared()});
+        return;
+    }
+
     let evaluationResponse = new EvaluationResponse((err, result) => {
         saveContext(this, request, context, evaluationResponse);
         callback(err, evaluationResponse.response);

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -43,7 +43,7 @@ Handler.prototype.initialize = function () {
  * @param callback - a callback function that gets the evaluation response
  */
 Handler.prototype.handleEvaluationRequest = function (request, callback) {
-    if(!this.engines || this.engines.length < 2) {
+    if(!this.engines) {
         callback({responseCode: 501, requestResult: errors.noNluDeclared()});
         return;
     }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -44,7 +44,7 @@ Handler.prototype.initialize = function () {
  */
 Handler.prototype.handleEvaluationRequest = function (request, callback) {
     if(!this.engines || this.engines.length < 1) {
-        callback({responseCode: 501, requestResult: errors.noNluDeclared()});
+        callback({responseCode: 500, requestResult: errors.noNluDeclared()});
         return;
     }
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -43,7 +43,7 @@ Handler.prototype.initialize = function () {
  * @param callback - a callback function that gets the evaluation response
  */
 Handler.prototype.handleEvaluationRequest = function (request, callback) {
-    if(!this.engines) {
+    if(!this.engines || this.engines.length < 1) {
         callback({responseCode: 501, requestResult: errors.noNluDeclared()});
         return;
     }

--- a/lib/server/api/controllers/evaluate-request.js
+++ b/lib/server/api/controllers/evaluate-request.js
@@ -19,6 +19,9 @@ function post(req, res) {
     }
     handler.handleEvaluationRequest(request, (err, result) => {
         if (err) {
+            if(err.responseCode) {
+                res.statusCode = err.responseCode;
+            }
             res.json(err);
         }
         else {

--- a/lib/server/api/swagger/swagger.yaml
+++ b/lib/server/api/swagger/swagger.yaml
@@ -102,6 +102,8 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/EvaluationResponse"
+        "501":
+          description: Not Implemented
 
   /healthcheck:
     x-swagger-router-controller: healthcheck

--- a/lib/server/api/swagger/swagger.yaml
+++ b/lib/server/api/swagger/swagger.yaml
@@ -102,8 +102,8 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/EvaluationResponse"
-        "501":
-          description: Not Implemented
+        "500":
+          description: Internal server error
 
   /healthcheck:
     x-swagger-router-controller: healthcheck


### PR DESCRIPTION
now when trying to call evaluate with no nlu engines declared or with just "skill" declared it will return a 501 error and an explanation.

this was only quickly tested by me