### PR TITLE
Stringify the Request logger.

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -94,7 +94,7 @@ Handler.prototype.evaluateRequest = function (request, evaluationResponse, conte
 };
 
 Handler.prototype.handleRequest = function (request, callback) {
-    logger.info('Request', {request});
+    logger.info('Request', JSON.stringify(request));
     // State and session context for short access
     let context = createContext(request);
     this.state = request.context.session.attributes.state;

--- a/lib/nlu/bundles/engines/wcs/workspace.js
+++ b/lib/nlu/bundles/engines/wcs/workspace.js
@@ -2,7 +2,6 @@
 © Copyright IBM Corp. 2017
 */
 
-
 'use strict';
 
 const watson = require('watson-developer-cloud');


### PR DESCRIPTION
Stringify the Request logger to show all key attributes. This will help with scanning through the request object on the console, or copy and pasting into a JSON formatter