### PR TITLE
use swagger for api security

### DIFF
--- a/lib/server/api/swagger/swagger.yaml
+++ b/lib/server/api/swagger/swagger.yaml
@@ -9,6 +9,11 @@ consumes:
 # format of the responses to the client (Accepts)
 produces:
   - application/json
+securityDefinitions:
+  api:
+    type: apiKey
+    in: header
+    name: expertiseKey
 paths:
   /manifest:
     x-swagger-router-controller: manifest
@@ -28,6 +33,8 @@ paths:
   /nlu:
     x-swagger-router-controller: nlu
     get:
+      security:
+        - api: []
       tags: [Resources]
       summary: Return natural language understanding resource
       description: Returns natural language undertsaning data for the specified
@@ -66,6 +73,8 @@ paths:
   /converse:
     x-swagger-router-controller: converse
     post:
+      security:
+        - api: []
       tags: [Converse]
       summary: Converse with skill
       description: Returns the skill response to a user query
@@ -86,6 +95,8 @@ paths:
   /evaluate:
     x-swagger-router-controller: evaluate-request
     post:
+      security:
+        - api: []
       tags: [Evaluate]
       summary: Evaluate request confidence
       description: Returns the skill's confidence for this request

--- a/lib/server/security/api.js
+++ b/lib/server/security/api.js
@@ -1,0 +1,36 @@
+/*
+ * Licensed Materials - Property of IBM
+ * (c) Copyright IBM Corporation 2017. All Rights Reserved.
+ */
+const logger = require('winston');
+
+/**
+ * Return a promise with the authentication of other "things" that can use this API
+ * @method authenticate
+ * @param  {string}     apikey the key that is passed into this api
+ * @return {object}            if successfully passes security check, it passses
+ * control to the callback; otherwise passes error object to the callback
+ */
+function authenticate(apikey) {
+    if (!process.env.AUTHENTICATE_REQUESTS) {
+        return Promise.resolve(true);
+    }
+    if (process.env.API_KEY === apikey) {
+        return Promise.resolve(true);
+    }
+    return Promise.reject(new Error("Unauthorized access attempt.  API Key missing or incorrect."));
+}
+
+module.exports = (req, securityDefinition, apiKey, cb) => {
+    authenticate(apiKey)
+        .then((result) => {
+            logger.info(`authenticated with apiKey ${apiKey}`);
+            cb();
+        })
+        .catch((err) => {
+            logger.error(err.message);
+            const error = new Error('Unauthorized access request. Incorrect API key.');
+            error.statusCode = 401;
+            cb(error);
+        });
+};

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -23,7 +23,10 @@ module.exports = app;
 
 let config = {
     appRoot: __dirname, // required config
-    configDir: __dirname + '/config'
+    configDir: __dirname + '/config',
+    swaggerSecurityHandlers: {
+        api: require('./security/api'),
+    }
 };
 
 // REST logging
@@ -34,40 +37,6 @@ app.use(morgan('short', {
         }
     }
 }));
-
-// Checks that the request for the expertise came from the core
-app.all('/*', function (req, res, next) {
-    req.skillKey = req.headers.expertisekey;
-    // check only if defined to be a secured expertise
-    if (process.env.AUTHENTICATE_REQUESTS && JSON.parse(process.env.AUTHENTICATE_REQUESTS.toLowerCase())) {
-        let coreKey = "";
-        let valid = false;
-        let isConverse = (req.url.indexOf('converse') > 0);
-        let isEvaluate = (req.url.indexOf('evaluate') > 0);
-        let isDocs = (req.url.indexOf('api-docs') > 0);
-        // let is_manifest = (req.url.indexOf('manifest') > 0);
-        // let is_healthcheck = (req.url.indexOf('healthcheck') > 0);
-        if (isConverse || isDocs || isEvaluate) {
-            coreKey = getKey(req);
-            valid = authenticate(coreKey);
-        }
-        else {
-            valid = true;
-        }
-        // check if key is in the list of key and is not undefined
-        // let is_manifest = req.url.indexOf('manifest');
-        if (!valid) {
-            logger.info('authentication failed, key: ' + coreKey + "\n request url: " + req.url);
-            res.send(401)
-        } else {
-            logger.info('authentication succeeded, key: ' + coreKey + "\n request url: " + req.url);
-            next();
-        }
-    }
-    else {
-        next();
-    }
-});
 
 SwaggerExpress.create(config, function (err, swaggerExpress) {
 
@@ -91,9 +60,9 @@ SwaggerExpress.create(config, function (err, swaggerExpress) {
 
 
 });
-let getKeys = function() {
-    return fs.readFileSync(path.join(process.env.skillSDKResDir, assetsFolder, keysFileName), 'utf8', function(err, contents) {
-        if(err){
+let getKeys = function () {
+    return fs.readFileSync(path.join(process.env.skillSDKResDir, assetsFolder, keysFileName), 'utf8', function (err, contents) {
+        if (err) {
             logger.info('could not read keys file, error: ' + err);
             return "";
         }
@@ -123,11 +92,11 @@ let getKey = function (req) {
 
 
 
-let authenticate = function(core_key) {
+let authenticate = function (core_key) {
     // check if the core key is found in the list of keys
     let keys = getKeys();
-    for (let i=0; i < keys.length; ++i) {
-        if(keys[i] === core_key) {
+    for (let i = 0; i < keys.length; ++i) {
+        if (keys[i] === core_key) {
             return true;
         }
     }


### PR DESCRIPTION
I recommend a few changes to the way API key is handled by WPA.  Swagger has built in capability to handle API keys, so I updated the swagger to use that and protect a few specific routes.  I recommend that the NLU route be protected as it contains credentials for the skills WCS space that could be used for bad intent.

I also recommend that the API_KEY be stored in a environmental variable as opposed to a text file within the res folder.  This will allow the skill developer to set the key how they wish.  For example, they could add it to a .env file or store it in their CF or use a secret within Kubernetes.  