### PR TITLE
Offer #145 skillkey in header

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -37,7 +37,11 @@ app.use(morgan('short', {
 
 // Checks that the request for the expertise came from the core
 app.all('/*', function (req, res, next) {
-    req.skillKey = req.headers.expertisekey;
+    if(req.headers.expertisekey) {
+        req.skillKey = req.headers.expertisekey;
+    } else if(req.headers.skillKey) {
+        req.skillKey = req.headers.skillKey;
+    }
     // check only if defined to be a secured expertise
     if (process.env.AUTHENTICATE_REQUESTS && JSON.parse(process.env.AUTHENTICATE_REQUESTS.toLowerCase())) {
         let coreKey = "";

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -39,8 +39,8 @@ app.use(morgan('short', {
 app.all('/*', function (req, res, next) {
     if(req.headers.expertisekey) {
         req.skillKey = req.headers.expertisekey;
-    } else if(req.headers.skillKey) {
-        req.skillKey = req.headers.skillKey;
+    } else if(req.headers.skillkey) {
+        req.skillKey = req.headers.skillkey;
     }
     // check only if defined to be a secured expertise
     if (process.env.AUTHENTICATE_REQUESTS && JSON.parse(process.env.AUTHENTICATE_REQUESTS.toLowerCase())) {
@@ -106,7 +106,7 @@ let getKeys = function () {
 };
 
 let getKey = function (req) {
-    let key = req.header('expertiseKey') || req.query['api_key'];
+    let key = req.header('expertiseKey') || req.header('skillKey') ||req.query['api_key'];
 
     if (!key) {
         let query;


### PR DESCRIPTION
added the option to send skillKey in the header in addition to expertiseKey (not both)
tested.
git issue: https://github.ibm.com/ConsumerIoT/WA-dev-issues/issues/145