### PR TITLE
add condition to only use env creds for wcs nlu

### DIFF
--- a/lib/nlu/factory.js
+++ b/lib/nlu/factory.js
@@ -126,7 +126,7 @@ function getNLU(type, name) {
             let nlu;
             if(process.env.WCS_USERNAME && process.env.WCS_URL && process.env.WCS_PASSWORD && process.env.WCS_VERSION_DATE
                 && process.env.WCS_VERSION && process.env.WCS_WORKSPACE_ID && process.env.WCS_WORKSPACE_NAME &&
-                process.env.WCS_WORKSPACE_LANGUAGE) {
+                process.env.WCS_WORKSPACE_LANGUAGE && type == 'wcs') {
                 nlu = createNLUFromEnv();
             } else {
                 nlu = require(`${resPath}/nlu/${type}`);

--- a/lib/nlu/factory.js
+++ b/lib/nlu/factory.js
@@ -126,7 +126,7 @@ function getNLU(type, name) {
             let nlu;
             if(process.env.WCS_USERNAME && process.env.WCS_URL && process.env.WCS_PASSWORD && process.env.WCS_VERSION_DATE
                 && process.env.WCS_VERSION && process.env.WCS_WORKSPACE_ID && process.env.WCS_WORKSPACE_NAME &&
-                process.env.WCS_WORKSPACE_LANGUAGE && type == 'wcs') {
+                process.env.WCS_WORKSPACE_LANGUAGE && type === 'wcs') {
                 nlu = createNLUFromEnv();
             } else {
                 nlu = require(`${resPath}/nlu/${type}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-sdk-nodejs",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "This is the SDK to be used when developing a skill for Watson Assistant Solutions using Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-sdk-nodejs",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "This is the SDK to be used when developing a skill for Watson Assistant Solutions using Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
A PR for a bug discovered by investigating [this](https://github.ibm.com/ConsumerIoT/WA-dev-issues/issues/852) issue regarding regex NLU engine failing to initiate when the skill is started in "wcs" and "regexp" mode with a corresponding .env file containing the wcs credentials.